### PR TITLE
Audio support added for cast screen/screen mirroring.

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -5,7 +5,7 @@
 global_configuration {
   attached_output_devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER
   default_output_device AUDIO_DEVICE_OUT_SPEAKER
-  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC
+  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX
 }
 
 # audio hardware module section: contains descriptors for all audio hw modules present on the
@@ -47,7 +47,7 @@ audio_hw_modules {
     inputs {
       primary {
         sampling_rates 8000|11025|12000|16000|22050|24000|32000|44100|48000
-        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO
+        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO|AUDIO_CHANNEL_IN_FRONT_BACK
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_WIRED_HEADSET|AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET|AUDIO_DEVICE_IN_VOICE_CALL|AUDIO_DEVICE_IN_BACK_MIC
       }
@@ -56,7 +56,7 @@ audio_hw_modules {
   a2dp {
     outputs {
       a2dp {
-        sampling_rates 44100
+        sampling_rates 44100|48000
         channel_masks AUDIO_CHANNEL_OUT_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_OUT_ALL_A2DP
@@ -82,7 +82,7 @@ audio_hw_modules {
   r_submix {
     outputs {
       submix {
-        sampling_rates 44100|48000
+        sampling_rates 48000
         channel_masks AUDIO_CHANNEL_OUT_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_OUT_REMOTE_SUBMIX
@@ -90,7 +90,7 @@ audio_hw_modules {
     }
     inputs {
       submix {
-        sampling_rates 44100|48000
+        sampling_rates 48000
         channel_masks AUDIO_CHANNEL_IN_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_IN_REMOTE_SUBMIX


### PR DESCRIPTION
Video/Audio is working perfectly fine even after adding remote submix tested by me personally( I own Xperia ZL(odin)), I am using this feature regularly with my Sony Smart TV. ( For cm11 if I add this video was not working properly but  this works flawlessly with cm 12.1)
